### PR TITLE
feat: add 'Send to Gemini CLI' context menu action

### DIFF
--- a/src/main/kotlin/com/google/gemini/cli/SendFileToGeminiCliAction.kt
+++ b/src/main/kotlin/com/google/gemini/cli/SendFileToGeminiCliAction.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 thxwelchs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gemini.cli
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.wm.ToolWindowManager
+import org.jetbrains.plugins.terminal.ShellTerminalWidget
+import java.awt.Component
+import java.nio.charset.StandardCharsets
+import javax.swing.JComponent
+
+class SendFileToGeminiCliAction : AnAction() {
+  private val LOG = Logger.getInstance(SendFileToGeminiCliAction::class.java)
+
+  override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+  override fun actionPerformed(e: AnActionEvent) {
+    val project = e.project ?: return
+    val virtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+    val editor = e.getData(CommonDataKeys.EDITOR)
+
+    // Use relative path for more concise terminal input
+    val projectDir = project.guessProjectDir()
+    val path = if (projectDir != null) {
+      VfsUtilCore.getRelativePath(virtualFile, projectDir) ?: virtualFile.path
+    } else {
+      virtualFile.path
+    }
+    
+    var textToSend = " @$path"
+
+    if (editor != null && editor.selectionModel.hasSelection()) {
+      val document = editor.document
+      val selectionModel = editor.selectionModel
+      val startLine = document.getLineNumber(selectionModel.selectionStart) + 1
+      val endOffset = if (selectionModel.selectionEnd > selectionModel.selectionStart) {
+        selectionModel.selectionEnd - 1
+      } else {
+        selectionModel.selectionEnd
+      }
+      val endLine = document.getLineNumber(endOffset) + 1
+
+      textToSend += if (startLine == endLine) ":$startLine" else ":$startLine-$endLine"
+    }
+
+    try {
+      val toolWindow = ToolWindowManager.getInstance(project).getToolWindow("Terminal")
+      if (toolWindow != null && toolWindow.isVisible) {
+        val content = toolWindow.contentManager.selectedContent
+        val widget = findTerminalWidget(content?.component)
+
+        if (widget != null) {
+          val ttyConnector = widget.ttyConnector
+          if (ttyConnector != null) {
+            ttyConnector.write(textToSend.toByteArray(StandardCharsets.UTF_8))
+          }
+        }
+      }
+    } catch (e: Exception) {
+      LOG.error("Failed to inject text into terminal", e)
+    }
+  }
+
+  private fun findTerminalWidget(component: Component?): ShellTerminalWidget? {
+    if (component == null) return null
+    if (component is ShellTerminalWidget) return component
+    if (component is JComponent) {
+      for (child in component.components) {
+        val found = findTerminalWidget(child)
+        if (found != null) return found
+      }
+    }
+    return null
+  }
+
+  override fun update(e: AnActionEvent) {
+    val project = e.project
+    val virtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE)
+    
+    if (project == null || virtualFile == null) {
+      e.presentation.isEnabledAndVisible = false
+      return
+    }
+
+    e.presentation.isEnabledAndVisible = hasGeminiTerminal(project)
+  }
+
+  private fun hasGeminiTerminal(project: Project): Boolean {
+    val toolWindow = ToolWindowManager.getInstance(project).getToolWindow("Terminal") ?: return false
+    if (!toolWindow.isAvailable) return false
+    
+    val contentManager = toolWindow.contentManager
+    return (0 until contentManager.contentCount).any { index ->
+      val content = contentManager.getContent(index)
+      content?.displayName?.contains("Gemini", ignoreCase = true) == true
+    }
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -61,5 +61,10 @@
       description="Show Gemini CLI notices and licenses">
       <add-to-group group-id="ToolsMenu" anchor="last"/>
     </action>
+    <action id="SendFileToGeminiCli" class="com.google.gemini.cli.SendFileToGeminiCliAction" text="Send to Gemini CLI"
+      description="Send file path to Gemini CLI" icon="/icons/icon.svg">
+      <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+      <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+    </action>
   </actions>
 </idea-plugin>


### PR DESCRIPTION
When using the Gemini CLI within the IDE's integrated terminal, developers often need to reference specific files or code blocks. Manually typing out file paths or copy-pasting code is a repetitive task that breaks the
  development flow.
  
  
 **Changes**
  This PR introduces a new context menu action, "Send to Gemini CLI", available in both the Project View and the Editor.

   - Automated Path Injection: Automatically injects the project-relative file path (e.g., @src/main/main.kt) into the active Gemini terminal session.
   - Selection Support: If a code block is selected in the editor, it automatically appends the line range (e.g., @src/main/main.kt:10-25).
   - Smart Visibility: The action only appears when a terminal tab with "Gemini" in its name is active and visible, ensuring a clean UI.
   - Direct Interaction: Uses TtyConnector to simulate direct user input in the terminal, providing a seamless experience.